### PR TITLE
Fixed singular replacement of "ies" to "y"

### DIFF
--- a/JSONExport/StringExtension.swift
+++ b/JSONExport/StringExtension.swift
@@ -49,7 +49,7 @@ extension String{
             }
                 
         }
-        if length > 2{
+        else if length > 2{
             let range = Range(start: advance(endIndex, -1), end: endIndex)
             let lastChar = self.substringWithRange(range)
             if lastChar == "s" {


### PR DESCRIPTION
The length > 2 was overruling the block that made "ies" to "y" so we ended up with words like "propertie". This patch fixes it.