### PR TITLE
Update Swift-Mappable spec to the latest Mappable protocol definition

### DIFF
--- a/JSONExport/PredefinedLanguages/Swift-Mappable.json
+++ b/JSONExport/PredefinedLanguages/Swift-Mappable.json
@@ -34,8 +34,8 @@
     "constructors": [
                      {
                      "comment": "",
-                     "signature": "\trequired init?(_ map: Map)",
-                     "bodyStart": "{\n\t\tmapping(map)",
+                     "signature": "\tclass func newInstance() -> Mappable",
+                     "bodyStart": "{\n\t\treturn <!ModelName!>()",
                      "bodyEnd": "\n\t}\n",
                      "fetchBasicTypePropertyFromMap": "",
                      "fetchBasicTypeWithSpecialNeedsPropertyFromMap": "",


### PR DESCRIPTION
The Mappable protocol has changed a bit. (https://github.com/Hearst-DD/ObjectMapper)

```swift 
required init?(_ map: Map) 
```

is now replaced by 

```swift
static func newInstance() -> Mappable
```

I've changed the spec file to reflect those changes