### PR TITLE
fix a complier error in SwiftyJSON - Class

### DIFF
--- a/JSONExport/Supported Languages/SwiftyJSON-Class.json
+++ b/JSONExport/Supported Languages/SwiftyJSON-Class.json
@@ -77,7 +77,7 @@
                        "forEachCustomTypeProperty": "\t\tif <!VarName!> != nil{\n\t\t\tdictionary[\"<!JsonKeyName!>\"] = <!VarName!>.toDictionary()\n\t\t}\n",
                        "forEachArrayOfCustomTypeProperty": "\t\tif <!VarName!> != nil{\n\t\t\tvar dictionaryElements = [[String:Any]]()\n\t\t\tfor <!VarName!>Element in <!VarName!> {\n\t\t\t\tdictionaryElements.append(<!VarName!>Element.toDictionary())\n\t\t\t}\n\t\t\tdictionary[\"<!JsonKeyName!>\"] = dictionaryElements\n\t\t}\n",
                        "returnStatement": "\t\treturn dictionary\n",
-                       "body": "\t\tlet dictionary = [String:Any]()\n",
+                       "body": "\t\tvar dictionary = [String:Any]()\n",
                        "comment": "\t/**\n\t * Returns all the available property values in the form of [String:Any] object where the key is the approperiate json key and the value is the value of the corresponding property\n\t */\n",
                        "bodyStart": "\n\t{\n"
                        },


### PR DESCRIPTION
use "let" will make the dictionary a constant. Change it to "var", or it will cause a compiler error.