### PR TITLE
Fix Xcode build-time error : Change generic type from 'AnyObject' to 'String' -> Fixes #105

### DIFF
--- a/JSONExport/Supported Languages/Swift-Codable.json
+++ b/JSONExport/Supported Languages/Swift-Codable.json
@@ -99,7 +99,7 @@
                      }
                      ],
     "modelDefinition": "\nstruct <!ModelName!> : Codable ",
-    "genericType": "AnyObject",
+    "genericType": "String",
     "getter": "",
     "setter": "",
     "fileExtension": "swift",


### PR DESCRIPTION
In Swift-Struct-Codable format 'decodeIfPresent' cannot
produce value of type 'Anyobject'. So changing geberic-type
from 'AnyObject'to 'String' for null json values will
allow to compile the xcode project

Fixes #105 

Related to #96 