### PR TITLE
fixed: update the color under Dark Mode

### DIFF
--- a/JSONExport.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/JSONExport.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/JSONExport/ViewController.swift
+++ b/JSONExport/ViewController.swift
@@ -98,6 +98,7 @@ class ViewController: NSViewController, NSUserNotificationCenterDelegate, NSTabl
         setLanguagesSelection()
         loadLastSelectedLanguage()
         updateUIFieldsForSelectedLanguage()
+		self.tableView.backgroundColor = .clear
     }
     
     /**


### PR DESCRIPTION
### What I done

update the color under Dark Mode

### Issue

JSONExport under Dark Mode

![darkmode](https://user-images.githubusercontent.com/535675/64401633-4dcceb80-d0a4-11e9-8ad7-af7a35e6e039.png)

JSONExport under Light Mode

![lightmode](https://user-images.githubusercontent.com/535675/64401654-6c32e700-d0a4-11e9-9362-e3e207cad21f.png)

From the above images, we can find that the color of Text under Dark Mode is not right.

### Fixed & How

JSONExport under Dark Mode

![fixed-darkmode](https://user-images.githubusercontent.com/535675/64401692-9be1ef00-d0a4-11e9-8679-3ad598e6bf82.png)

JSONExport under Light Mode

![fixed-lightmode](https://user-images.githubusercontent.com/535675/64401699-a7351a80-d0a4-11e9-9925-da3d1e051f6e.png)

From the above images, Dark Mode is cool now.

Just tableView's backgroundColor.

